### PR TITLE
feat: Add BCH token for chain ID 56

### DIFF
--- a/src/utils/token.utils.ts
+++ b/src/utils/token.utils.ts
@@ -160,6 +160,14 @@ export const tokens = [
     "chainId": 56,
     "decimals": 18,
     "logoURI": "https://raw.githubusercontent.com/goblinscash/goblins-icons/main/icons/bonk.png"
+  },
+  {
+    "name": "Bitcoin Cash",
+    "symbol": "BCH",
+    "address": "0x8fF795a6F4D97E7887C79beA79aba5cc76444aDf",
+    "chainId": 56,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/goblinscash/goblins-icons/main/icons/bcbch.png"
   }
 ]
 


### PR DESCRIPTION
Re-adds the Bitcoin Cash (BCH) token definition to `src/utils/token.utils.ts` for chain ID 56.
- Name: Bitcoin Cash
- Symbol: BCH
- Address: 0x8fF795a6F4D97E7887C79beA79aba5cc76444aDf
- ChainID: 56
- Decimals: 18
- LogoURI: https://raw.githubusercontent.com/goblinscash/goblins-icons/main/icons/bcbch.png

The corresponding entry in `tokenLogos` was verified to be already present and correct.