### PR TITLE
The commit you're looking at modifies the `tokens` list in `src/utils…

### DIFF
--- a/src/utils/token.utils.ts
+++ b/src/utils/token.utils.ts
@@ -1,5 +1,7 @@
 import { stableTokens } from "./constant.utils"
 
+const testTokenSymbols = ['tGOB', 'tETH', 'tUSDC', 'tUSDT', 'tBCH'];
+
 export const tokens = [
   {
     "name": "Goblin V2",
@@ -161,7 +163,7 @@ export const tokens = [
     "decimals": 18,
     "logoURI": "https://raw.githubusercontent.com/goblinscash/goblins-icons/main/icons/bcbch.png"
   }
-]
+].filter(token => !testTokenSymbols.includes(token.symbol));
 
 export const tokenLogos = {
   "0x5ca35ebc4f25b042d2cae75914c7e882e631fa9a": "https://raw.githubusercontent.com/goblinscash/goblins-icons/main/icons/neiro.png",


### PR DESCRIPTION
…/token.utils.ts` to exclude test tokens (tGOB, tETH, tUSDC, tUSDT, tBCH). This ensures that these tokens are no longer displayed in user-facing token selection modals or lists. The filtering is applied directly to the source `tokens` array, so all downstream consumers of this list will receive the filtered version.